### PR TITLE
Wextra fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,8 +14,8 @@ else
 OPTIMISE_FLAGS=
 endif
 
-CC_FLAGS=-Wall $(OPTIMISE_FLAGS)
-LD_FLAGS=-Wall $(OPTIMISE_FLAGS)
+CC_FLAGS=-Wall -Wextra $(OPTIMISE_FLAGS)
+LD_FLAGS=-Wall -Wextra $(OPTIMISE_FLAGS)
 SERVER_LIBS=-lssl -lcrypto -lpthread
 CLIENT_LIBS=-lssl -lcrypto
 

--- a/src/hash_table.c
+++ b/src/hash_table.c
@@ -225,7 +225,7 @@ void ff_hash_table_remove_item(struct ff_hash_table *hash_table, uint64_t item_i
     if (buckets->nodes == NULL)
     {
         // Walk back up tree clearing unused buckets
-        for (uint8_t level = hash_table->bucket_levels - 2; level >= 0; level--)
+        for (uint8_t level = hash_table->bucket_levels - 2; ; level--)
         {
             bool should_free = true;
             union ff_hash_table_bucket *bucket_level = bucket_list[level];

--- a/src/http.c
+++ b/src/http.c
@@ -146,7 +146,7 @@ bool ff_http_send_request_unencrypted(struct ff_request *request, char *host_nam
         }
 
         sent += chunk;
-    } while (sent < request->payload_length);
+    } while (sent < (int)request->payload_length);
 
     ff_log(FF_DEBUG, "Finished sending request to %s over HTTP (%d bytes sent)", host_name, sent);
 
@@ -171,7 +171,7 @@ bool ff_http_send_request_unencrypted(struct ff_request *request, char *host_nam
         {
             break;
         }
-    } while (received < sizeof(response) - 1);
+    } while (received < (int)sizeof(response) - 1);
 
     ff_log(FF_DEBUG, "Finished receiving response from %s (%d bytes received)", host_name, received);
     size_t response_header_length = strchr((char *)response, '\n') - response;

--- a/src/parser.c
+++ b/src/parser.c
@@ -47,7 +47,7 @@ bool ff_request_is_raw_http(uint32_t buff_size, void *buff)
 
     bool is_raw_http = false;
 
-    for (int i = 0; i < (sizeof(HTTP_METHODS) / sizeof(HTTP_METHODS[0])); i++)
+    for (int i = 0; i < (int)(sizeof(HTTP_METHODS) / sizeof(HTTP_METHODS[0])); i++)
     {
         is_raw_http |= strncmp(HTTP_METHODS[i], buff, strlen(HTTP_METHODS[i])) == 0;
 

--- a/src/signals.c
+++ b/src/signals.c
@@ -5,7 +5,7 @@
 #include <string.h>
 #include "constants.h"
 
-void ff_sigint_handler(int signal)
+void ff_sigint_handler(int signal __attribute__((unused)))
 {
     char message[] = "Interrupt signal received, terminating process!\n";
     write(STDOUT_FILENO, message, sizeof(message));


### PR DESCRIPTION
Hi,

Here is a set of patches that change to compiling the server & client with -Wextra for extra language diagnostics.

Then there are follow up commits for fixing the various warnings introduced.

This was compiled/tested under Fedora 31 with GCC 9.3

NOTE: Without FF_OPTIMIZE there are two failing tests, these fail without these patches. With FF_OPTIMIZE all tests pass.

Cheers,
Andrew