### PR TITLE
Fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,9 +14,9 @@ else
 OPTIMISE_FLAGS=
 endif
 
-CC_FLAGS=-Wall -Wextra $(OPTIMISE_FLAGS)
-LD_FLAGS=-Wall -Wextra $(OPTIMISE_FLAGS)
-SERVER_LIBS=-lssl -lcrypto -lpthread
+CC_FLAGS=-Wall -Wextra -std=c99 -D_GNU_SOURCE $(OPTIMISE_FLAGS)
+LD_FLAGS=-Wall -Wextra -std=c99 $(OPTIMISE_FLAGS)
+SERVER_LIBS=-lm -lssl -lcrypto -lpthread
 CLIENT_LIBS=-lssl -lcrypto
 
 build: build_server build_client

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ OPTIMISE_FLAGS=
 endif
 
 CC_FLAGS=-Wall -Wextra -std=c99 -D_GNU_SOURCE $(OPTIMISE_FLAGS)
-LD_FLAGS=-Wall -Wextra -std=c99 $(OPTIMISE_FLAGS)
+LD_FLAGS=
 SERVER_LIBS=-lm -lssl -lcrypto -lpthread
 CLIENT_LIBS=-lssl -lcrypto
 
@@ -82,7 +82,7 @@ client/crypto.o: client/c/crypto.c
 # Tests
 
 test_build: build
-	$(LD) $(LD_FLAGS) -o build/tests $(filter-out build/obj/main.o, $(wildcard build/obj/*.o)) \
+	$(CC) $(CC_FLAGS) $(LD_FLAGS) -o build/tests $(filter-out build/obj/main.o, $(wildcard build/obj/*.o)) \
 									 $(filter-out build/obj/client/main.o, $(wildcard build/obj/client/*.o)) \
 									 tests/include/*.c tests/run.c $(SERVER_LIBS)
 

--- a/src/config.c
+++ b/src/config.c
@@ -3,6 +3,7 @@
 #include <stdlib.h>
 #include <stdint.h>
 #include <string.h>
+#include <strings.h>
 #include <arpa/inet.h>
 #include "main.h"
 #include "config.h"

--- a/src/server.c
+++ b/src/server.c
@@ -2,6 +2,7 @@
 #include <unistd.h>
 #include <stdlib.h>
 #include <string.h>
+#include <sys/types.h>
 #include <sys/socket.h>
 #include <netinet/in.h>
 #include <netdb.h>


### PR DESCRIPTION
Hi,

Here are some fixes for compiling on older systems such as CentOS 7 and hopefully will also fix issue #9 

Secondly there is a commit to clean up the LD_FLAGS Makefile variable. Its options just mirrored CC_FLAGS, but those only affect compilation and not linking.

Cheers,
Andrew
