### PR TITLE
Don't cast the return pointer from [cm]alloc(3)

### DIFF
--- a/src/crypto.c
+++ b/src/crypto.c
@@ -36,13 +36,13 @@ void ff_decrypt_request(struct ff_request *request, struct ff_encryption_key *ke
 
         case FF_REQUEST_OPTION_TYPE_ENCRYPTION_IV:
             iv_len = request->options[i]->length;
-            iv = (uint8_t *)malloc(iv_len);
+            iv = malloc(iv_len);
             memcpy(iv, request->options[i]->value, iv_len * sizeof(uint8_t));
             break;
 
         case FF_REQUEST_OPTION_TYPE_ENCRYPTION_TAG:
             tag_len = request->options[i]->length;
-            tag = (uint8_t *)malloc(tag_len);
+            tag = malloc(tag_len);
             memcpy(tag, request->options[i]->value, tag_len * sizeof(uint8_t));
             break;
 
@@ -133,7 +133,7 @@ bool ff_decrypt_request_aes_256_gcm(
     int len;
     bool ret_val;
 
-    uint8_t *plaintext_buff = (uint8_t *)malloc(request->payload_length * sizeof(uint8_t));
+    uint8_t *plaintext_buff = malloc(request->payload_length * sizeof(uint8_t));
     int plaintext_len = 0;
     int ret;
     struct ff_request_payload_node *payload_chunk = request->payload;

--- a/src/hash_table.c
+++ b/src/hash_table.c
@@ -19,7 +19,7 @@ struct ff_hash_table *ff_hash_table_init(uint8_t prefix_bit_length)
 {
     assert(prefix_bit_length > 0);
 
-    struct ff_hash_table *hash_table = (struct ff_hash_table *)malloc(sizeof(struct ff_hash_table));
+    struct ff_hash_table *hash_table = malloc(sizeof(struct ff_hash_table));
 
     hash_table->length = 0;
     *(uint8_t *)&hash_table->prefix_bit_length = prefix_bit_length;
@@ -34,7 +34,7 @@ struct ff_hash_table *ff_hash_table_init(uint8_t prefix_bit_length)
 
 union ff_hash_table_bucket *ff_hash_table_init_bucket()
 {
-    union ff_hash_table_bucket *buckets = (union ff_hash_table_bucket *)calloc(1, sizeof(union ff_hash_table_bucket) * FF_BUCKET_POOL_LENGTH);
+    union ff_hash_table_bucket *buckets = calloc(1, sizeof(union ff_hash_table_bucket) * FF_BUCKET_POOL_LENGTH);
 
     return buckets;
 }
@@ -130,7 +130,7 @@ void ff_hash_table_put_item(struct ff_hash_table *hash_table, uint64_t item_id, 
     }
 
     // Store new item in hash table
-    struct ff_hash_table_node *new_node = (struct ff_hash_table_node *)calloc(1, sizeof(struct ff_hash_table_node));
+    struct ff_hash_table_node *new_node = calloc(1, sizeof(struct ff_hash_table_node));
     new_node->item_id = item_id;
     new_node->value = item;
 
@@ -166,7 +166,7 @@ void ff_hash_table_remove_item(struct ff_hash_table *hash_table, uint64_t item_i
 {
     pthread_mutex_lock(&ff_hash_table_data_mutex);
 
-    union ff_hash_table_bucket **bucket_list = (union ff_hash_table_bucket **)calloc(1, sizeof(union ff_hash_table_bucket *) * hash_table->bucket_levels);
+    union ff_hash_table_bucket **bucket_list = calloc(1, sizeof(union ff_hash_table_bucket *) * hash_table->bucket_levels);
     union ff_hash_table_bucket *buckets = ff_hash_table_get_or_create_bucket(hash_table, item_id, true, bucket_list);
 
     if (buckets == NULL || buckets->nodes == NULL)
@@ -274,7 +274,7 @@ struct ff_hash_table_iterator *ff_hash_table_iterator_init(struct ff_hash_table 
 {
     pthread_mutex_lock(&ff_hash_table_data_mutex);
 
-    struct ff_hash_table_iterator *iterator = (struct ff_hash_table_iterator *)calloc(1, sizeof(struct ff_hash_table_iterator));
+    struct ff_hash_table_iterator *iterator = calloc(1, sizeof(struct ff_hash_table_iterator));
     iterator->hash_table = hash_table;
     iterator->current_node = NULL;
     iterator->started = false;

--- a/src/http.c
+++ b/src/http.c
@@ -372,7 +372,7 @@ cleanup:
 char *ff_http_get_destination_host(struct ff_request *request)
 {
     // @see https://stackoverflow.com/questions/8724954/what-is-the-maximum-number-of-characters-for-a-host-name-in-unix
-    char *host_name = (char *)malloc(_POSIX_HOST_NAME_MAX + 1);
+    char *host_name = malloc(_POSIX_HOST_NAME_MAX + 1);
     char *http_request = (char *)request->payload->value;
     char *line = http_request;
     uint64_t payload_len = request->payload_length;

--- a/src/parser.c
+++ b/src/parser.c
@@ -308,7 +308,7 @@ void ff_request_vectorise_payload(struct ff_request *request)
     payload->length = request->payload_length;
     payload->offset = 0;
     payload->next = NULL;
-    payload->value = (uint8_t *)malloc(request->payload_length * sizeof(uint8_t));
+    payload->value = malloc(request->payload_length * sizeof(uint8_t));
 
     struct ff_request_payload_node *node = request->payload;
     struct ff_request_payload_node *tmp_node = NULL;

--- a/src/request.c
+++ b/src/request.c
@@ -9,7 +9,7 @@
 
 struct ff_request_option_node *ff_request_option_node_alloc()
 {
-    struct ff_request_option_node *option = (struct ff_request_option_node *)malloc(sizeof(struct ff_request_option_node));
+    struct ff_request_option_node *option = malloc(sizeof(struct ff_request_option_node));
 
     option->type = 0;
     option->length = 0;
@@ -20,7 +20,7 @@ struct ff_request_option_node *ff_request_option_node_alloc()
 
 void ff_request_option_load_buff(struct ff_request_option_node *node, uint32_t buff_size, void *buff)
 {
-    void *buff_copy = (char *)malloc(buff_size * sizeof(buff));
+    void *buff_copy = malloc(buff_size * sizeof(buff));
 
     memcpy(buff_copy, buff, buff_size);
 
@@ -39,7 +39,7 @@ void ff_request_option_node_free(struct ff_request_option_node *option)
 
 struct ff_request_payload_node *ff_request_payload_node_alloc()
 {
-    struct ff_request_payload_node *node = (struct ff_request_payload_node *)malloc(sizeof(struct ff_request_payload_node));
+    struct ff_request_payload_node *node = malloc(sizeof(struct ff_request_payload_node));
 
     node->length = 0;
     node->offset = 0;
@@ -51,7 +51,7 @@ struct ff_request_payload_node *ff_request_payload_node_alloc()
 
 void ff_request_payload_load_buff(struct ff_request_payload_node *node, uint32_t buff_size, void *buff)
 {
-    void *buff_copy = (char *)malloc(buff_size * sizeof(buff));
+    void *buff_copy = malloc(buff_size * sizeof(buff));
 
     memcpy(buff_copy, buff, buff_size);
 
@@ -70,7 +70,7 @@ void ff_request_payload_node_free(struct ff_request_payload_node *node)
 
 struct ff_request *ff_request_alloc()
 {
-    struct ff_request *request = (struct ff_request *)calloc(1, sizeof(struct ff_request));
+    struct ff_request *request = calloc(1, sizeof(struct ff_request));
 
     request->state = FF_REQUEST_STATE_RECEIVING;
 

--- a/src/server.c
+++ b/src/server.c
@@ -182,7 +182,7 @@ void ff_proxy_process_incoming_packet(struct ff_config *config, struct ff_hash_t
     case FF_REQUEST_STATE_RECEIVED:
         ff_log(FF_DEBUG, "Finished receiving incoming request");
 
-        thread_args = (struct ff_process_request_args *)malloc(sizeof(struct ff_process_request_args));
+        thread_args = malloc(sizeof(struct ff_process_request_args));
         thread_args->config = config;
         thread_args->request = request;
         thread_args->requests = requests;
@@ -258,7 +258,7 @@ void ff_proxy_clean_up_old_requests_loop(struct ff_hash_table *requests)
 
         struct ff_hash_table_iterator *iterator = ff_hash_table_iterator_init(requests);
         struct ff_request *request = NULL;
-        struct ff_request **requests_to_remove = (struct ff_request **)calloc(1, requests->length * sizeof(struct ff_request *));
+        struct ff_request **requests_to_remove = calloc(1, requests->length * sizeof(struct ff_request *));
         uint32_t count = 0;
 
         while ((request = ff_hash_table_iterator_next(iterator)) != NULL)


### PR DESCRIPTION
Hi,

First I acknowledge that this may be contentious, so no worries if you choose not to apply this.

Some background.

In C, you don't need to (and perhaps really shouldn't) cast the return pointer from calloc/malloc/realloc etc. In fact doing so can hide bugs.

See [0] for a lengthy debate on the topic... also note the "Exceptions" from [1]. But the general consensus seems to be that you shouldn't cast the pointer returned, and I'm firmly in that camp...

Cheers,
Andrew

[0]: https://stackoverflow.com/questions/605845/do-i-cast-the-result-of-malloc
[1]: https://wiki.sei.cmu.edu/confluence/display/c/MEM02-C.+Immediately+cast+the+result+of+a+memory+allocation+function+call+into+a+pointer+to+the+allocated+type