### PR TITLE
client/c: Don't cast the return pointer from [cm]alloc(3)

### DIFF
--- a/client/c/client.c
+++ b/client/c/client.c
@@ -107,7 +107,7 @@ void ff_client_read_payload_from_file(struct ff_request *request, FILE *fd)
     }
 
     request->payload = ff_request_payload_node_alloc();
-    request->payload->value = (uint8_t *)malloc(sizeof(buffer));
+    request->payload->value = malloc(sizeof(buffer));
 
     while ((chunk_length = fread(buffer, 1, sizeof(buffer), fd)) != 0)
     {
@@ -131,7 +131,7 @@ void ff_client_read_payload_from_file(struct ff_request *request, FILE *fd)
 
 struct ff_client_packet *ff_client_packetise_request(struct ff_request *request, uint16_t *packet_count)
 {
-    struct ff_client_packet *packets = (struct ff_client_packet *)calloc(1, sizeof(struct ff_client_packet *) * FF_CLIENT_MAX_PACKETS);
+    struct ff_client_packet *packets = calloc(1, sizeof(struct ff_client_packet *) * FF_CLIENT_MAX_PACKETS);
     uint64_t request_id = ff_client_generate_request_id();
     uint32_t chunk_offset = 0;
     uint16_t bytes_left = request->payload_length;
@@ -140,7 +140,7 @@ struct ff_client_packet *ff_client_packetise_request(struct ff_request *request,
 
     while (bytes_left > 0)
     {
-        uint8_t *buffer = (uint8_t *)calloc(1, FF_CLIENT_MAX_PACKET_LENGTH);
+        uint8_t *buffer = calloc(1, FF_CLIENT_MAX_PACKET_LENGTH);
         uint16_t packet_length = 0;
         struct __raw_ff_request_header *header = (struct __raw_ff_request_header *)buffer;
 

--- a/client/c/crypto.c
+++ b/client/c/crypto.c
@@ -83,7 +83,7 @@ bool ff_client_encrypt_request_aes_256_gcm(
     int len;
     bool ret_val;
 
-    uint8_t *ciphertext_buff = (uint8_t *)malloc(request->payload_length * sizeof(uint8_t));
+    uint8_t *ciphertext_buff = malloc(request->payload_length * sizeof(uint8_t));
     int ciphertext_len = 0;
     struct ff_request_payload_node *payload_chunk = request->payload;
 
@@ -91,7 +91,7 @@ bool ff_client_encrypt_request_aes_256_gcm(
     memcpy(padded_key, key->key, strlen((char *)key->key));
 
     *iv_len = 12;
-    *iv = (uint8_t *)calloc(1, *iv_len);
+    *iv = calloc(1, *iv_len);
 
     if (!RAND_bytes(*iv, *iv_len))
     {
@@ -143,7 +143,7 @@ bool ff_client_encrypt_request_aes_256_gcm(
 
     ciphertext_len += len;
     *tag_len = 16;
-    *tag = (uint8_t *)calloc(1, 16);
+    *tag = calloc(1, 16);
 
     if (!EVP_CIPHER_CTX_ctrl(ctx, EVP_CTRL_GCM_GET_TAG, *tag_len, *tag))
     {


### PR DESCRIPTION
Hi,

Like for the server, don't cast the return pointer from malloc/calloc.

Cheers,
Andrew
