### PR TITLE
http: Skip hostname validation for OpenSSL < 1.0.2

### DIFF
--- a/src/http.c
+++ b/src/http.c
@@ -213,7 +213,6 @@ bool ff_http_send_request_tls(struct ff_request *request, char *host_name)
     long res = 1;
 
     SSL_CTX *ctx = NULL;
-    X509_VERIFY_PARAM *param = NULL;
     BIO *web = NULL;
     SSL *ssl = NULL;
     char error_string[256] = {0};
@@ -277,13 +276,18 @@ bool ff_http_send_request_tls(struct ff_request *request, char *host_name)
         goto error;
     }
 
-    param = SSL_get0_param(ssl);
-    res = X509_VERIFY_PARAM_set1_host(param, host_name, strlen(host_name));
-    if (res != 1)
+#ifndef OPENSSL_SKIP_HOST_VALIDATION
     {
-        ff_log(FF_ERROR, "Failed to set OpenSSL param host name");
-        goto error;
+        X509_VERIFY_PARAM *param = SSL_get0_param(ssl);
+
+        res = X509_VERIFY_PARAM_set1_host(param, host_name, strlen(host_name));
+        if (res != 1)
+        {
+            ff_log(FF_ERROR, "Failed to set OpenSSL param host name");
+            goto error;
+        }
     }
+#endif
 
     SSL_set_verify(ssl, SSL_VERIFY_PEER, NULL);
 


### PR DESCRIPTION
Hi,

ff-proxy is using some OpenSSL functions that were only introduced in 1.0.2, these are for doing hostname validation, While it can be done in OpenSSL prior ro 1.0.2, it's quite convoluted[0]

For this use case it's perhaps better to just skip it with OpenSSL older than 1.0.2

Hopefully this is the last of fixes needed for #9 (famous last words!).

Cheers,
Andrew

[0]: https://wiki.openssl.org/index.php/Hostname_validation